### PR TITLE
Added some comments

### DIFF
--- a/src/day1.rs
+++ b/src/day1.rs
@@ -1,14 +1,12 @@
-use std::collections::HashMap;
 use log;
-
+use std::collections::HashMap;
 
 fn part1(input: &str) -> String {
-
     let mut first_list: Vec<u32> = Vec::new();
     let mut second_list: Vec<u32> = Vec::new();
 
     // split the input by lines
-    for line in input.lines(){
+    for line in input.lines() {
         log::debug!("{}", line);
         let mut first: String = String::new();
         let mut second: String = String::new();
@@ -37,18 +35,15 @@ fn part1(input: &str) -> String {
         i = i + 1;
     }
 
-
     format!("{}", result)
 }
 
-
 fn part2(input: &str) -> String {
-
     let mut first_list: HashMap<u32, u32> = HashMap::new();
     let mut second_list: HashMap<u32, u32> = HashMap::new();
 
     // split the input by lines
-    for line in input.lines(){
+    for line in input.lines() {
         log::debug!("{}", line);
         let mut first: String = String::new();
         let mut second: String = String::new();
@@ -65,14 +60,39 @@ fn part2(input: &str) -> String {
         let first_number = first.parse::<u32>().unwrap();
         let second_number = second.parse::<u32>().unwrap();
 
-        *first_list.entry(first_number).or_insert(0) += 1;
-        *second_list.entry(second_number).or_insert(0) += 1;
+        //    *first_list.entry(first_number).or_insert(0) += 1;
+        //    *second_list.entry(second_number).or_insert(0) += 1;
+
+        // A common pattern in rust is to use a match statement to switch based on if a value is present or not.
+        // BTW: Your old way is more efficient and almost certainly better especially if the value is not a simple integer.
+        // It looks like references are common when dealing with map entries in rust, I just haven't needed to use them too much...
+        let current_first = match first_list.get(&first_number) {
+            Some(n) => n.to_owned(),
+            None => 0,
+        };
+        first_list.insert(first_number, current_first + 1);
+
+        // Alternatively, short hand for the same thing...
+        // unwrap_or is a common way to deal with Option types in rust
+        let current_second = second_list.get(&second_number).copied().unwrap_or(0);
+        second_list.insert(second_number, current_second + 1);
     }
 
     let mut result: u32 = 0;
 
     for n in first_list.keys() {
-        result += *n * first_list[n] * *second_list.entry(*n).or_insert(0);
+        // result += *n * first_list[n] * *second_list.entry(*n).or_insert(0);
+        // This is where I think the dereferences are a little bit confusing with the multiplier operator intermingled.
+
+        // I think this is nicer, it seems rust is happy to do arithmetic on a borrowed value and return a non-borrowed one (for simple types only)...
+        result += n * first_list[n] * second_list.get(n).unwrap_or(&0); // Note: This also avoids modifying the map, which we don't need do to in this situation.
+
+        // let n = n.to_owned(); // Fine in this case as it's a u32 (BTW: overriding a variable with the same name but different type is common in rust!!!)
+        // result += n * first_list[&n] * second_list.get(&n).copied().unwrap_or(0);
+
+        // If you wanted to keep the reference, but don't want to have * everywhere you use it...
+        // let n = *n;
+        // result += n * first_list[&n] * second_list.get(&n).copied().unwrap_or(0);
     }
 
     format!("{}", result)
@@ -85,7 +105,6 @@ fn main() {
     println!("Part1: {}", part1(&input));
     println!("Part2: {}", part2(&input));
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,21 @@
-use std::collections::HashMap;
-use log;
-use num_traits::sign::signum;
+// Importing this module might help with your IDE picking up the code?
+// If you don't have a module included via your main.rs file or lib.rs file, rust analyser won't analyse it :)
+mod day1;
 
+// You don't actually need any of these imports for this code...
+// use log;
+// use num_traits::sign::signum;
+// use std::collections::HashMap;
 
 fn part1(input: &str) -> String {
-
     let mut safe_count = 0;
 
     // split the input by lines
-    for line in input.lines(){
-
-        let levels: Vec<i32> = line.split(' ').map(|level| level.parse::<i32>().unwrap()).collect();
+    for line in input.lines() {
+        let levels: Vec<i32> = line
+            .split(' ')
+            .map(|level| level.parse::<i32>().unwrap())
+            .collect();
 
         let mut index = 0;
         let mut offset = 0;
@@ -71,12 +76,12 @@ fn pair_valid(a: i32, b: i32, direction: i32) -> bool {
             } else {
                 println!("Valid: {} {} {}", a, b, direction);
             }
-            return offset != 0
+            return offset != 0;
         }
         offset += 1;
         if offset > 3 {
             println!("Not valid: {} {} {}", a, b, direction);
-            return false
+            return false;
         }
     }
 }
@@ -98,10 +103,12 @@ fn level_valid(levels: Vec<i32>, direction: i32) -> bool {
             tolerated = true;
 
             if index + 2 == levels.len() {
-                return true
+                return true;
             }
 
-            let can_remove_first = (index == 0 || pair_valid(levels[index - 1], levels[index + 1], direction)) && pair_valid(levels[index + 1], levels[index + 2], direction);
+            let can_remove_first = (index == 0
+                || pair_valid(levels[index - 1], levels[index + 1], direction))
+                && pair_valid(levels[index + 1], levels[index + 2], direction);
             let can_remove_second = pair_valid(levels[index], levels[index + 2], direction);
             if !can_remove_first && !can_remove_second {
                 return false;
@@ -112,15 +119,15 @@ fn level_valid(levels: Vec<i32>, direction: i32) -> bool {
     }
 }
 
-
 fn part2(input: &str) -> String {
-
     let mut safe_count = 0;
 
     // split the input by lines
     for line in input.lines() {
-
-        let levels: Vec<i32> = line.split(' ').map(|level| level.parse::<i32>().unwrap()).collect();
+        let levels: Vec<i32> = line
+            .split(' ')
+            .map(|level| level.parse::<i32>().unwrap())
+            .collect();
 
         if level_valid(levels.clone(), 1) || level_valid(levels.clone(), -1) {
             safe_count += 1;
@@ -137,7 +144,6 @@ fn main() {
     println!("Part1: {}", part1(&input));
     println!("Part2: {}", part2(&input));
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Put a few ideas/patterns in for the deref `*` question...

I think what you had was actually good, In our code base I'd probably lean towards a little bit more of a verbose option that was easier to understand as we don't do a lot of `deref'ng`.

Here's an example in our code base though...
https://github.com/msupply-foundation/open-msupply/blob/41f37b8b032444912e48b90e20bb316e45907f1d/server/service/src/item_stats.rs#L126

I remember in c having plenty of weird things like `**some_pointer_name +=1;` I think it's not too different when you're trying to manipulate variables in place...

If your code base is doing a lot of map manipulations I think how you were using it is probably a good way and the team would be familiar with the pattern.

I'd probably just avoid using multiplication and de-ref in the same line, as I think that's inherently confusing...